### PR TITLE
Add dependency install instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ jquery to save your lab notebooks locally.
 
     git clone --recursive https://github.com/voidptr/noodle_notebook.git
 
+If you don't already have the packages flask, flask_flatpages, and markdown2 then you'll need to grab them.
+
+    sudo pip3 install flask
+    sudo pip3 install flask_flatpages
+    sudo pip3 install markdown2
+
 ## Configuring Noodle (DO NOT SKIP)
 
 Configure by editing the headers of app.py. Specifically, you’ll want to

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ jquery to save your lab notebooks locally.
 
 ## installing Noodle
 
-    git clone --recursive https://github.com/voidptr/noodle_notebook.git 
+    git clone --recursive https://github.com/voidptr/noodle_notebook.git
 
 ## Configuring Noodle (DO NOT SKIP)
 
@@ -27,7 +27,7 @@ To run:
 
 Then, navigate to: <http://127.0.0.1:5000/>
 
-## What is Noodle? 
+## What is Noodle?
 
 Noodle is a flat-file lab notebook that saves your files as plain html
 in the location of your choice.


### PR DESCRIPTION
Potential novice users may not know how to install the Python packages they're missing (or be able to interpret the error messages they get running the app for the first time and even know they're missing packages!).